### PR TITLE
Update to add base Swift 6 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/ComposableArchitecturePattern/Extensions/URLResponse+Extensions.swift
+++ b/Sources/ComposableArchitecturePattern/Extensions/URLResponse+Extensions.swift
@@ -21,7 +21,7 @@ public extension URLResponse {
 			case 400...499:
 				throw ServerAPIError.network(description: httpResponse.description)
 			case 500...599:
-				throw ServerAPIError.server(description: httpResponse.description, httpStatusCode: httpResponse.statusCode, jsonObject: nil)
+				throw ServerAPIError.server(description: httpResponse.description, httpStatusCode: httpResponse.statusCode)
 			default:
 				throw ServerAPIError.unknown(description: "Unknown HTTPURLResponse: \(httpResponse.description)")
 		}

--- a/Sources/ComposableArchitecturePattern/Server+API.swift
+++ b/Sources/ComposableArchitecturePattern/Server+API.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An object that specifies a specific server API.
 ///
 /// - Note: It is highly encouraged to define your `supportedReturnObjects` to ensure `-supports<T: Decodable>(_:)` is able to automatically verify against this.
-public protocol ServerAPI: Identifiable, Equatable {
+public protocol ServerAPI: Identifiable, Equatable, Sendable {
 	/// The environment this API should be used against. Default is `nil`.
 	/// - Note: If it can be used against any environment, leave it `nil`.
 	var environment: ServerEnvironment? { get }

--- a/Sources/ComposableArchitecturePattern/Server+Courier.swift
+++ b/Sources/ComposableArchitecturePattern/Server+Courier.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public protocol Courier {
+public protocol Courier: Sendable {
 	/// Send the given request to the server.
 	/// - Returns: A boolean indicating the success of the request.
 	/// - Throws: A `ServerAPIError` if unable to decode or an error encountered during the request.

--- a/Sources/ComposableArchitecturePattern/ServerAPIError.swift
+++ b/Sources/ComposableArchitecturePattern/ServerAPIError.swift
@@ -22,7 +22,7 @@ public enum ServerAPIError: Error {
 	/// Functionality to complete the API request is incomplete.
 	case notImplemented(description: String? = nil)
 	/// An error occurred with the server.
-	case server(description: String? = nil, httpStatusCode: Int, jsonObject: Any? = nil)
+	case server(description: String? = nil, httpStatusCode: Int)
 	/// A task cancellation occurred.
 	case taskCancelled(description: String? = nil, error: Error? = nil)
 	/// An error occurred while attempting to decode.


### PR DESCRIPTION
This bumps CAP support to 6.1. One arguable change was removing `jsonObject` from `ServerAPIError`. However, seeing as this wasn't really used in CAP and `Any` would prohibit Swift 6 _and_ picking a replacement type for it may prove counter productive, it seems the right approach would be to get rid of it entirely.