### PR TITLE
Updates to base Coordinator function

### DIFF
--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -27,13 +27,13 @@ public protocol Coordinator {
 	/// An enumeration of supported actions of the coordinator.
 	associatedtype Actions
 	/// Perform the specified enum action asynchronously.
+	@available(*, deprecated, message: "This method has been deprecated. Use `perform(action:) -> Results` instead.")
+	func perform(action: Actions) async throws
+	
+	/// Perform the specified enum action asynchronously.
 	/// - Returns: The specified result.
 	@discardableResult
 	func perform(action: Actions) async throws -> Results
-	
-	/// Perform the specified enum action asynchronously.
-	@available(*, deprecated, message: "This method has been deprecated. Use `perform(action:) -> Results` instead.")
-	func perform(action: Actions) async throws
 	
 	/// An enumeration of actions to sync to.
 	associatedtype SyncActions

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -30,6 +30,10 @@ public protocol Coordinator {
 	@discardableResult
 	func perform(action: Actions) async throws -> Results
 	
+	/// Perform the specified enum action asynchronously.
+	@available(*, deprecated, message: "This method has been deprecated. Use `perform(action:) -> Results` instead.")
+	func perform(action: Actions) async throws
+	
 	/// An enumeration of actions to sync to.
 	associatedtype SyncActions
 	/// Sync the coordinator to the specified stream.
@@ -52,6 +56,8 @@ extension Coordinator {
 	}
 	
 	public func perform(action: EmptyActions) async throws -> EmptyResults {}
+	
+	public func peform(action: EmptyActions) async throws {}
 	
 	public func sync(to stream: AsyncStream<EmptyActions>) {}
 }

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -29,6 +29,13 @@ public protocol Coordinator {
 	/// Perform the specified enum action asynchronously.
 	@discardableResult
 	func perform(action: Actions) async throws -> Results
+	
+	/// An enumeration of actions to sync to.
+	associatedtype SyncActions
+	/// Sync the coordinator to the specified stream.
+	///
+	/// Use this if there is some action or function that is dependent upon some other coordinator's `statusStream` or some other asynchronous stream.
+	func sync(to stream: AsyncStream<SyncActions>)
 }
 
 extension Coordinator {
@@ -45,6 +52,8 @@ extension Coordinator {
 	}
 	
 	public func perform(action: EmptyActions) async throws -> EmptyResults {}
+	
+	public func sync(to stream: AsyncStream<EmptyActions>) {}
 }
 
 /// The state of the coordinator.

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -19,6 +19,9 @@ public protocol Coordinator {
 	
 	/// An enumeration of expected results
 	associatedtype Results
+	/// A stream of current events corresponding to the coordinator's status.
+	///
+	/// This stream is useful to react to the coordinator's change in status, such as when the coordinator is finished loading or if the coordinator needs to reload.
 	var statusStream: AsyncStream<CoordinatorStatus<Actions, Results>> { get }
 	
 	/// An enumeration of supported actions of the coordinator.
@@ -70,7 +73,9 @@ public enum CoordinatorState: Equatable {
 }
 
 public enum CoordinatorStatus<A, R> {
+	/// The specified action was handled by the coordinator with the specified result. `result` is defaulted to `nil` because there may be scenarios where you don't want to expose the result of the action, such as when a coordinator may be handling sensitive data or data that is irrelevant outside the context of the coordinator.
 	case actionHandled(action: A, result: R? = nil)
+	/// The coordinator's state was updated to the specified new state.
 	case stateUpdated(newState: CoordinatorState)
 }
 

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -17,10 +17,15 @@ public protocol Coordinator {
 	/// Perform any necessary function to reload the coordinator.
 	func reload() async
 	
+	/// An enumeration of expected results
+	associatedtype Results
+	var statusStream: AsyncStream<CoordinatorStatus<Actions, Results>> { get }
+	
 	/// An enumeration of supported actions of the coordinator.
 	associatedtype Actions
 	/// Perform the specified enum action asynchronously.
-	func perform(action: Actions) async throws
+	@discardableResult
+	func perform(action: Actions) async throws -> Results
 }
 
 extension Coordinator {
@@ -51,6 +56,11 @@ public enum CoordinatorState: Equatable {
 	case needsReload
 	/// The coordinator is in an error state.
 	case error(error: Error? = nil, description: String? = nil)
+}
+
+public enum CoordinatorStatus<A, R> {
+	case actionHandled(action: A, result: R)
+	case stateUpdated(newState: CoordinatorState)
 }
 
 /// An object that coordinates between view, networking, or other logic

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -33,6 +33,17 @@ extension Coordinator {
 	public func reload() async {}
 }
 
+public enum EmptyActions {}
+public enum EmptyResults {}
+
+extension Coordinator {
+	public var statusStream: AsyncStream<CoordinatorStatus<EmptyActions, EmptyResults>> {
+		AsyncStream { _ in }
+	}
+	
+	public func perform(action: EmptyActions) async throws -> EmptyResults {}
+}
+
 /// The state of the coordinator.
 public enum CoordinatorState: Equatable {
 	public static func == (lhs: Self, rhs: Self) -> Bool {

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -70,7 +70,7 @@ public enum CoordinatorState: Equatable {
 }
 
 public enum CoordinatorStatus<A, R> {
-	case actionHandled(action: A, result: R)
+	case actionHandled(action: A, result: R? = nil)
 	case stateUpdated(newState: CoordinatorState)
 }
 

--- a/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
+++ b/Sources/ComposableArchitecturePattern/ViewCoordinator.swift
@@ -27,6 +27,7 @@ public protocol Coordinator {
 	/// An enumeration of supported actions of the coordinator.
 	associatedtype Actions
 	/// Perform the specified enum action asynchronously.
+	/// - Returns: The specified result.
 	@discardableResult
 	func perform(action: Actions) async throws -> Results
 	


### PR DESCRIPTION
The goal of this PR is to expand coordinator functionality so a coordinator is practically more useful and more composable. 

The new `statusStream` property is designed to allow listening to a coordinator's current events to allow reaction, if appropriate. An example of this might be using a coordinator for sidebar views and wanting to know when the coordinator and its view are loaded and ready. This may be useful during start up or some other similar scenario. Another example might be when a specific coordinator has completed a task to react to it in another coordinator, such as when loading preferences from a server and then reloading a certain coordinator's view based on the preferences being loaded. You would take the stream from one coordinator and use it to sync the other coordinator:
```
let preferencesCoordinator = PreferencesCoordinator()
let sidebarCoordinator = SidebarCoordinator()

...

func load() async throws {
    self.sidebarCoordinator.sync(to: self. preferencesCoordinator.statusStream)
}
```